### PR TITLE
Fix rows/cols in `domains` description

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The variables listed here are set by the user in the NACC run script, and they a
     WRF Lambert Conformal reference latitude. Use this setting to force the reference latitude in the output NACC data. If not set, NACC will use the average of the two true latitudes.
 -   `projparm [FV3GFS-Only; used  to define projection parameters for subset of global grid; example set: GDTYP=2, P_ALP=33., P_BET=45., P_GAM=-97., XCENT=-97., YCENT=40.]`  
     Required definition of grid projection parameters for FV3GFS. Use this setting to subset the FV3-GFS global domain that is regridded to use in CMAQ.
--   `domains [FV3GFS-Only; used  to define domain grid information for subset of global grid; example set XORIG=-2508000., YORIG=-1716000., DX=12000., DY=12000., NROWS=442, NCOLS=265]`  
+-   `domains [FV3GFS-Only; used  to define domain grid information for subset of global grid; example set XORIG=-2508000., YORIG=-1716000., DX=12000., DY=12000., NCOLS=442, NROWS=265]`  
     Required definition of grid domain parameters for FV3GFS. Use this setting to subset the FV3-GFS global domain that is regridded to use in CMAQ.
 -   `ntimes [WRF and FV3GFS; default = 0]`  
     Number of times to process for the model


### PR DESCRIPTION
Comments in the code

https://github.com/noaa-oar-arl/NACC/blob/607050bd028aa325fc6a34d57187aef083361969/serial/src/mcipparm_mod.f90#L374

suggest `NCOLS` should be first (and @drnimbusrain confirmed)